### PR TITLE
Ofreshy pass 1

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -17,9 +17,7 @@
 
 ```
 if you use pip: 
-> pip3 install pandas
-> pip3 install scipy
-> pip3 install jupyter
+> pip3 install -r requirements.txt
 	
 if you use anaconda
 > conda install pandas

--- a/notebooks/notebook-0-data-gathering.ipynb
+++ b/notebooks/notebook-0-data-gathering.ipynb
@@ -488,7 +488,7 @@
    ],
    "source": [
     "# the personal ratings are now stored together with the rest of the ratings\n",
-    "ratings.ix[ratings.customer == my_customer_number]"
+    "ratings.loc[ratings.customer == my_customer_number]"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+jupyter==
+pandas==0.20.3
+scipy==0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jupyter==
+jupyter==1.0.0
 pandas==0.20.3
-scipy==0.16.0
+scipy==0.19.1


### PR DESCRIPTION
Added requirements.txt file, and updated instructions for pip users to install it

use .loc instead of .ix since the latter is deprecated - 
```
DeprecationWarning: 
.ix is deprecated. Please use
.loc for label based indexing or
.iloc for positional indexing
```
